### PR TITLE
Add autoloads

### DIFF
--- a/google-translate-core-ui.el
+++ b/google-translate-core-ui.el
@@ -90,7 +90,7 @@
 ;;; Code:
 ;;
 
-;; (require 'google-translate)
+(require 'google-translate-core)
 (require 'ido)
 
 

--- a/google-translate-default-ui.el
+++ b/google-translate-default-ui.el
@@ -199,6 +199,7 @@ becomes the default target language and vice versa."
               (google-translate-language-display-name source-language)
               (google-translate-language-display-name target-language))))))
 
+;;;###autoload
 (defun google-translate-query-translate (&optional override-p)
   "Interactively translate text with Google Translate.
 
@@ -226,6 +227,7 @@ Translate to detect the source language."
   (interactive "P")
   (%google-translate-query-translate override-p nil))
 
+;;;###autoload
 (defun google-translate-query-translate-reverse (&optional override-p)
   "Like `google-translate-query-translate', but performs translation
 in the reverse direction.
@@ -251,6 +253,7 @@ in the reverse direction."
        (or (current-word t)
            (error "No word at point."))))))
 
+;;;###autoload
 (defun google-translate-at-point (&optional override-p)
   "Translate the word at point or the words in the active region.
 
@@ -258,6 +261,7 @@ For the meaning of OVERRIDE-P, see `google-translate-query-translate'."
   (interactive "P")
   (%google-translate-at-point override-p nil))
 
+;;;###autoload
 (defun google-translate-at-point-reverse (&optional override-p)
   "Like `google-translate-at-point', but performs translation in the
 reverse direction."

--- a/google-translate-smooth-ui.el
+++ b/google-translate-smooth-ui.el
@@ -344,6 +344,7 @@ direction."
   (cdr (nth google-translate-current-translation-direction
             google-translate-translation-directions-alist)))
 
+;;;###autoload
 (defun google-translate-smooth-translate ()
   "Translate a text using translation directions.
 

--- a/google-translate.el
+++ b/google-translate.el
@@ -69,7 +69,6 @@
 
 ;;; Code:
 
-(require 'google-translate-core)
 (require 'google-translate-default-ui)
 
 (provide 'google-translate)


### PR DESCRIPTION
I have added autoloads for the main commands, so if the package is
installed from marmalade/melpa, a user can use those commands without
requiring features.

Also `(require 'google-translate-core)` was moved to the
`google-translate-core-ui.el` because this file relies on the core
functions, and autoloads don't work without that require.  This require
is not necessary for `google-translate.el`.
