### PR TITLE
Marker characters should be trimmed from translating word

### DIFF
--- a/features/google-translate-default-ui.feature
+++ b/features/google-translate-default-ui.feature
@@ -4,7 +4,7 @@ Feature: Default UI for Google Translate
     Given default UI
     Given I am in buffer "*Lorem Ipsum*"
     And the buffer is empty
-    And I insert "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+    And I insert "Lorem Ipsum is simply =dummy= text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
 
   Scenario: Translate a word at point
     Given I go to word "dummy"

--- a/features/google-translate-default-ui.feature
+++ b/features/google-translate-default-ui.feature
@@ -4,7 +4,7 @@ Feature: Default UI for Google Translate
     Given default UI
     Given I am in buffer "*Lorem Ipsum*"
     And the buffer is empty
-    And I insert "Lorem Ipsum is simply =dummy= text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+    And I insert "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
 
   Scenario: Translate a word at point
     Given I go to word "dummy"
@@ -123,3 +123,38 @@ Feature: Default UI for Google Translate
     And I press "RET"
     Then I should see translation "предлагать"
     
+  Scenario: Translate a word emphasized with asterisks like *bold* such as in Org mode
+    Given I insert "You can make words *bold*, /italic/, _underlined_, =verbatim= and ~code~, and, if you must, ‘+strike-through+’."
+    And I go to word "bold"
+    When I translate word at point from "en" to "ru"
+    Then I should see translation "жирный"
+
+  Scenario: Translate a word emphasized with slashes like /italic/ such as in Org mode
+    Given I insert "You can make words *bold*, /italic/, _underlined_, =verbatim= and ~code~, and, if you must, ‘+strike-through+’."
+    And I go to word "italic"
+    When I translate word at point from "en" to "ru"
+    Then I should see translation "курсив"
+
+  Scenario: Translate a word emphasized with underscores like _underlined_ such as in Org mode
+    Given I insert "You can make words *bold*, /italic/, _underlined_, =verbatim= and ~code~, and, if you must, ‘+strike-through+’."
+    And I go to word "underlined"
+    When I translate word at point from "en" to "ru"
+    Then I should see translation "подчеркнутый"
+
+  Scenario: Translate a word emphasized with equals signs like =verbatim= such as in Org mode
+    Given I insert "You can make words *bold*, /italic/, _underlined_, =verbatim= and ~code~, and, if you must, ‘+strike-through+’."
+    And I go to word "verbatim"
+    When I translate word at point from "en" to "ru"
+    Then I should see translation "дословно"
+
+  Scenario: Translate a word emphasized with tildes like ~code~ such as in Org mode
+    Given I insert "You can make words *bold*, /italic/, _underlined_, =verbatim= and ~code~, and, if you must, ‘+strike-through+’."
+    And I go to word "code"
+    When I translate word at point from "en" to "ru"
+    Then I should see translation "код"
+
+  Scenario: Translate a word emphasized with pluses like ‘+strike-through+’ such as in Org mode
+    Given I insert "You can make words *bold*, /italic/, _underlined_, =verbatim= and ~code~, and, if you must, ‘+strike-through+’."
+    And I go to word "strike"
+    When I translate word at point from "en" to "ru"
+    Then I should see translation "забастовка"

--- a/features/google-translate-smooth-ui.feature
+++ b/features/google-translate-smooth-ui.feature
@@ -66,3 +66,39 @@ Feature: Smooth UI for Google Translate
     And I press "TAB"
     And I press "RET"
     Then I should see translation "предлагать"
+
+  Scenario: Translate a word emphasized with asterisks like *bold* such as in Org mode
+    Given I insert "You can make words *bold*, /italic/, _underlined_, =verbatim= and ~code~, and, if you must, ‘+strike-through+’."
+    And I go to word "bold"
+    When I translate word at point from "en" to "ru"
+    Then I should see translation "жирный"
+
+  Scenario: Translate a word emphasized with slashes like /italic/ such as in Org mode
+    Given I insert "You can make words *bold*, /italic/, _underlined_, =verbatim= and ~code~, and, if you must, ‘+strike-through+’."
+    And I go to word "italic"
+    When I translate word at point from "en" to "ru"
+    Then I should see translation "курсив"
+
+  Scenario: Translate a word emphasized with underscores like _underlined_ such as in Org mode
+    Given I insert "You can make words *bold*, /italic/, _underlined_, =verbatim= and ~code~, and, if you must, ‘+strike-through+’."
+    And I go to word "underlined"
+    When I translate word at point from "en" to "ru"
+    Then I should see translation "подчеркнутый"
+
+  Scenario: Translate a word emphasized with equals signs like =verbatim= such as in Org mode
+    Given I insert "You can make words *bold*, /italic/, _underlined_, =verbatim= and ~code~, and, if you must, ‘+strike-through+’."
+    And I go to word "verbatim"
+    When I translate word at point from "en" to "ru"
+    Then I should see translation "дословно"
+
+  Scenario: Translate a word emphasized with tildes like ~code~ such as in Org mode
+    Given I insert "You can make words *bold*, /italic/, _underlined_, =verbatim= and ~code~, and, if you must, ‘+strike-through+’."
+    And I go to word "code"
+    When I translate word at point from "en" to "ru"
+    Then I should see translation "код"
+
+  Scenario: Translate a word emphasized with pluses like ‘+strike-through+’ such as in Org mode
+    Given I insert "You can make words *bold*, /italic/, _underlined_, =verbatim= and ~code~, and, if you must, ‘+strike-through+’."
+    And I go to word "strike"
+    When I translate word at point from "en" to "ru"
+    Then I should see translation "забастовка"

--- a/google-translate-default-ui.el
+++ b/google-translate-default-ui.el
@@ -250,7 +250,7 @@ in the reverse direction."
      source-language target-language
      (if (use-region-p)
          (buffer-substring-no-properties (region-beginning) (region-end))
-       (or (current-word t)
+       (or (current-word t t)
            (error "No word at point."))))))
 
 ;;;###autoload

--- a/google-translate-smooth-ui.el
+++ b/google-translate-smooth-ui.el
@@ -380,7 +380,7 @@ one respectively."
         (if (use-region-p)
             (google-translate--strip-string
              (buffer-substring-no-properties (region-beginning) (region-end)))
-          (current-word t)))
+          (current-word t t)))
 
   (setq google-translate-current-translation-direction 0)
 


### PR DESCRIPTION
I think that the marker characters such as used in Org mode should be trimmed from translating word.
That characters are like this.

* `*text*`
* `/text/`
* `=text=`
* `~text~`

For example, especially when `google-translate-at-point` is run on `=text=`, then `=text=` is taken directly and translated. Google Translate returns the result, but it doesn't contain `noun` or `adjective` section.

This patch sets `t` to `REALLY-WORD` that is 2nd argument of `current-word` function to trim them.