### PR TITLE
Strip newlines in text to translate

### DIFF
--- a/google-translate-core-ui.el
+++ b/google-translate-core-ui.el
@@ -644,7 +644,8 @@ translation in the popup tooltip using `popup' package.
 To deal with multi-line regions, sequences of white space
 are replaced with a single space. If the region contains not text, a
 message is printed."
-  (let* ((json (google-translate-request source-language
+  (let* ((text (replace-regexp-in-string "\n" " " text))
+	 (json (google-translate-request source-language
                                          target-language
                                          text)))
     (if (null json)


### PR DESCRIPTION
It seems to me that Google Translate heuristics might yield different results when multi-line inputs are given as opposed to single-line inputs.
At least from English to German, it appears that the translation might be better without newlines.
Does Google Translate assume a period at the newline?