### PR TITLE
Fix Russian sentence in testing codes because travis ci fails

### DIFF
--- a/features/google-translate-default-ui.feature
+++ b/features/google-translate-default-ui.feature
@@ -35,7 +35,7 @@ Feature: Default UI for Google Translate
     And I go to word "but"
     And I translate selected region from "en" to "ru"
     Then there is no region selected
-    Then I should see translation "Он пережил не только пять веков"
+    Then I should see translation "Он пережил не только пять столетий,"
 
   Scenario: Translate a word at point using default source language
     Given I set google-translate-default-source-language to "en"

--- a/features/google-translate-smooth-ui.feature
+++ b/features/google-translate-smooth-ui.feature
@@ -51,7 +51,7 @@ Feature: Smooth UI for Google Translate
     And I go to word "but"
     And I translate ""
     Then there is no region selected
-    Then I should see translation "Он пережил не только пять веков"    
+    Then I should see translation "Он пережил не только пять столетий,"
 
   Scenario: Suggestion when word is misspelled
     Given I set google-translate-translation-directions-alist to (("en" . "ru"))


### PR DESCRIPTION
TravisCI fails because Google translate API translate "It has survived not only five centuries" into "
Он пережил не только пять столетий".