### PR TITLE
Provide backend functionalities to cope with google translate

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,46 @@ like so:
 ```
   (set-face-attribute 'google-translate-translation-face nil :height 1.4)
 ```
+#### Utilize curl, wget or else as a last resort
+
+If you have any troubles that relate to http, like `Search failed: ",tkk:'"`,
+try to use `curl` or `wget` for the backend method.
+
+The variable `'google-translate-backend-method` switches the backend
+method and currently available symbols are below:
+
+- emacs: use built in `url-retrieve-synchronously` (default)
+- curl: invoke curl
+- wget: invoke wget
+
+So if you prefer curl, put following line to your init.el:
+
+```
+(setq google-translate-backend-method 'curl)
+```
+
+In case neither curl nor wget is your preference, you can add another
+command to the variable `'google-translate-backend-commands` and
+employ it, for example:
+
+```
+(push '(foo :name "foo-x86" :args ("-q" "--agent"))
+      google-translate-backend-commands)
+(setq google-translate-backend-method 'foo)
+```
+
+For further information, please refer to the documentation of
+`'google-translate-backend-commands`.
+
+Additionally, these variables would be useful for troubleshooting:
+
+- `google-translate-backend-user-agent`, user agent string for HTTP
+  request header
+  (defaults to `"Emacs"`)
+
+- `google-translate-backend-debug`, log URL access activities to the
+  buffer `*google-translate-backend-debug*`
+  (defaults to nil)
 
 ## Contributors
 

--- a/google-translate-backend.el
+++ b/google-translate-backend.el
@@ -1,0 +1,142 @@
+;;; google-translate-backend.el --- Backend methods for url retrieve.
+
+;; Copyright (C) 2019 Tomotaka SUWA <tomotaka.suwa@gmail.com>
+
+;; Author: Oleksandr Manzyuk <manzyuk@gmail.com>
+;; Maintainer: Andrey Tykhonov <atykhonov@gmail.com>
+;; URL: https://github.com/atykhonov/google-translate
+;; Version: 0.11.17
+;; Keywords: convenience
+
+;; This file is NOT part of GNU Emacs.
+
+;; This is free software; you can redistribute it and/or modify it
+;; under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Provide backend facilities to cope with google translate.
+
+;;; Code:
+
+(defvar google-translate-backend-method 'emacs
+  "The backend method for URL retrieve.
+
+Valid symbols are below:
+
+ - emacs: use built in `url-retrieve-synchronously'
+ - curl: invoke curl command
+ - wget: invoke wget command
+
+and any other keys of `google-translate-backend-commands'.")
+
+(defvar google-translate-backend-user-agent "Emacs"
+  "The user agent string for HTTP request header.")
+
+(defvar google-translate-backend-commands
+  '((curl :args ("-s" "-L" "-A"))
+    (wget :args ("-q" "-O" "-" "-U")))
+  "An alist of external program specifications.
+
+The form of each element is (KEY P-LIST).  The variable
+`google-translate-backend-method' may have one of KEYs and is
+used for determine the command to execute.  The P-LIST of each
+element represents command specific information.
+
+Available properties:
+
+ - Property `:name': the program name(optional)
+ - Property `:args': a list of arguments passed to the program
+
+If you omit the `:name' property, (symbol-name KEY) will be used
+as the program name.  The `:args' property must be composed to
+satisfy all the following conditions:
+
+ - Output content to standard output
+ - Suppress non-content(HTTP headers, progress messages, etc)
+ - Handle location response header
+ - Place User-Agent option at last
+
+So if you would like to use another program \"foo\", for example:
+
+\(push \\='(foo :name \"foo-x86\"
+             :args (\"-q\" \"--agent\"))
+       google-translate-backend-commands)
+
+\(setq google-translate-backend-method \\='foo)
+
+And the command line looks like:
+
+foo-x86 -q --agent ['google-translate-backend-user-agent] [URL]")
+
+(defvar google-translate-backend-debug nil
+  "Non-nil means log http activities to the *google-translate-debug* buffer.")
+
+(defun google-translate-backend--log (&rest args)
+  "Log http activities to the *google-translate-debug* buffer along with ARGS.
+
+Disabled if `google-translate-backend-debug' is nil."
+  (when google-translate-backend-debug
+    (let ((message (mapconcat 'identity
+                              (list (current-time-string)
+                                    (prin1-to-string args)
+                                    "-- begin --"
+                                    (buffer-string)
+                                    "-- end --")
+                              "\n")))
+      (with-current-buffer
+          (get-buffer-create "*google-translate-backend-debug*")
+        (goto-char (point-max))
+        (insert message)
+        (newline)))))
+
+(defun google-translate-backend--emacs (url)
+  "Get URL contents by `url-retrieve-synchronously'."
+  (insert
+   (let ((url-user-agent google-translate-backend-user-agent))
+     (with-current-buffer (url-retrieve-synchronously url)
+       (set-buffer-multibyte t)
+       (google-translate-backend--log url 'emacs)
+       (goto-char (point-min))
+       (re-search-forward "\n\n")
+       (prog1 (buffer-substring (point)
+                                (point-max))
+         (kill-buffer))))))
+
+(defun google-translate-backend--process (url key spec)
+  "Get URL contents by `call-process'.
+
+\(KEY SPEC) would be exist in `google-translate-backend-commands'."
+  (let ((name (or (plist-get spec :name)
+                  (symbol-name key)))
+        (args (plist-get spec :args))
+        (agent google-translate-backend-user-agent))
+    (apply 'call-process
+           (append (list name nil t nil)
+                   args
+                   (list agent url)))
+    (google-translate-backend--log url key spec)))
+
+(defun google-translate-backend-retrieve (url)
+  "Get URL contents via `google-translate-backend-method'."
+  (let ((method google-translate-backend-method))
+    (if (eq method 'emacs)
+        (google-translate-backend--emacs url)
+      (let ((spec (cdr (assq method
+                             google-translate-backend-commands))))
+        (if (null spec)
+            (error "Unknown backend method: %s" method)
+          (google-translate-backend--process url method spec))))))
+
+(provide 'google-translate-backend)
+;;; google-translate-backend.el ends here

--- a/google-translate-core.el
+++ b/google-translate-core.el
@@ -119,17 +119,13 @@ QUERY-PARAMS must be an alist of field-value pairs."
 
 (defun google-translate--http-response-body (url &optional for-test-purposes)
   "Retrieve URL and return the response body as a string."
-  (with-current-buffer (url-retrieve-synchronously url)
-    (set-buffer-multibyte t)
-    (goto-char (point-min))
-    (when (null for-test-purposes)
-      (re-search-forward (format "\n\n"))
-      (delete-region (point-min) (point)))
-    (if (null for-test-purposes)
-        (prog1 
-            (buffer-string)
-          (kill-buffer))
-      (buffer-name))))
+  (let ((google-translate-backend-debug (or for-test-purposes
+                                            google-translate-backend-debug)))
+    (with-temp-buffer
+      (save-excursion
+        (google-translate-backend-retrieve url))
+      (set-buffer-multibyte t)
+      (buffer-string))))
 
 (defun google-translate--insert-nulls (string)
   "Google Translate responses with an almost valid JSON string

--- a/google-translate-tk.el
+++ b/google-translate-tk.el
@@ -39,6 +39,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'google-translate-backend)
 
 
 (defvar google-translate--bit-v-len 32)
@@ -134,9 +135,10 @@ D is an integer."
 
 (defun google-translate--get-b-d1 ()
   "Return a list of b and d1 for `google-translate--gen-tk'."
-  (let* ((url-request-extra-headers '(("Connection" . "close")))
-         (buf (url-retrieve-synchronously google-translate--tkk-url)))
-    (with-current-buffer buf
+  (let ((url-request-extra-headers '(("Connection" . "close"))))
+    (with-temp-buffer
+      (save-excursion (google-translate-backend-retrieve
+                       google-translate--tkk-url))
       (google-translate--search-tkk))))
 
 (defun google-translate--gen-rl (a b)


### PR DESCRIPTION
While it's important that finding out the root cause of the issue
#52 in order to fix it, how about providing a workaround by which
one can switch the backend method for URL access?

In my environment(*1), curl and wget work stably and do the great
job as alternatives.

Please note that I tried to keep backward compatibilities but
there is an exception:

```
-- Function: google-translate--http-response-body

When optional argument `for-test-purposes' is non-nil, the new
implementation logs URL access activities to the buffer
*google-translate-backend-debug* in contrary to the original
implementation returns the buffer containing http response.
```

Since I've been suffering issue #52 for a week, using built in
`url-retrieve-synchronously' is not tested yet and may have some
issues.  So sorry for that.

*1: GNU Emacs 26.1 (build 1 ,x86_64-w64-mingw32)
