### PR TITLE
Prevent odd translation result returned

### DIFF
--- a/google-translate-core.el
+++ b/google-translate-core.el
@@ -178,9 +178,7 @@ response in json format."
 translate TEXT from SOURCE-LANGUAGE to TARGET-LANGUAGE."
   (google-translate--http-response-body
    (google-translate--format-request-url
-    `(("client" . "t")
-      ("ie"     . "UTF-8")
-      ("oe"     . "UTF-8")
+    `(("client" . "webapp")
       ("sl"     . ,source-language)
       ("tl"     . ,target-language)
       ("q"      . ,text)


### PR DESCRIPTION
I don't know since when, but Google Translate has become to return an odd translation result that is before Google Translate become smarter for Japanese.
Fortunately, it was solved by changing `client=t` to `client=webapp` and removing `ie` and `oe` from URL parameters.