### PR TITLE
Use 'gtx' instead of 't' as ``client`` parameter.

### DIFF
--- a/google-translate-core.el
+++ b/google-translate-core.el
@@ -113,7 +113,7 @@ QUERY-PARAMS must be an alist of field-value pairs."
                                          ("total"   . "1")
                                          ("idx"     . "0")
                                          ("textlen" . ,(number-to-string (length text)))
-                                         ("client"  . "t")
+                                         ("client"  . "gtx")
                                          ("prev"    . "input")
                                          ("tk"      . ,(google-translate--gen-tk text)))))
 
@@ -178,7 +178,7 @@ response in json format."
 translate TEXT from SOURCE-LANGUAGE to TARGET-LANGUAGE."
   (google-translate--http-response-body
    (google-translate--format-request-url
-    `(("client" . "t")
+    `(("client" . "gtx")
       ("ie"     . "UTF-8")
       ("oe"     . "UTF-8")
       ("sl"     . ,source-language)


### PR DESCRIPTION
Use 'gtx' instead of 't' as ``client`` parameter.
(see https://github.com/matheuss/google-translate-api/issues/79 )