### PR TITLE
Fix buffer translate / smooth translate broken

### DIFF
--- a/google-translate-core-ui.el
+++ b/google-translate-core-ui.el
@@ -647,7 +647,8 @@ are replaced with a single space. If the region contains not text, a
 message is printed."
   (let* ((json (google-translate-request source-language
                                          target-language
-                                         text)))
+                                         text))
+	 (word-translate-t (= (length (split-string text)) 1)))
     (if (null json)
         (message "Nothing to translate.")
       (let* ((detailed-translation
@@ -665,7 +666,7 @@ message is printed."
                :translation-phonetic (google-translate-json-translation-phonetic json)
                :detailed-translation detailed-translation
                :detailed-definition detailed-definition
-               :suggestion (when (null detailed-translation)
+               :suggestion (when (and word-translate-t (null detailed-translation))
                              (google-translate-json-suggestion json))))
              (output-destination (if (null output-destination)
                                      google-translate-output-destination

--- a/google-translate-core.el
+++ b/google-translate-core.el
@@ -252,7 +252,7 @@ speech."
 does matter when translating misspelled word. So instead of
 translation it is possible to get suggestion."
   (let ((info (aref json 7)))
-    (when info
+    (when (and info (> (length info) 0))
       (aref info 1))))
 
 (defun google-translate-version ()


### PR DESCRIPTION
- This fix the bug reported at #98.
- We use the item with index [1] to query for the detailed
  translation. When this one is empty, we assume that there is a typo
  in the input message lead to no translation found by Google. But this
  lead to problems in two cases:
  + Sentence/paragraph translation: currently googles seems to always
  return empty as detailed translation for sentence mode.
  + Even for typo input, the suggestion seems no longer be returned in
  the same way as we can see so far.
- Check for sentence mode and skip looking for suggestions for now.
- Improve suggestion looking to be more robost by handling empty sequence.