### PR TITLE
Fix #78 Don't select word at point when pressed with C-u

### DIFF
--- a/google-translate-smooth-ui.el
+++ b/google-translate-smooth-ui.el
@@ -304,7 +304,8 @@ one respectively."
         (if (use-region-p)
             (google-translate--strip-string
              (buffer-substring-no-properties (region-beginning) (region-end)))
-          (current-word t t)))
+          (unless current-prefix-arg
+            (current-word t t))))
 
   (setq google-translate-current-translation-direction 0)
 


### PR DESCRIPTION
Add a condition to detect `[C-u]` universal prefix argument. So user can write a custom defiend command to without word at point. Mainly fix this issue #78 