### PR TITLE
Let command `google-translate-paragraphs-overlay` support org-mode

### DIFF
--- a/google-translate-core-ui.el
+++ b/google-translate-core-ui.el
@@ -770,7 +770,9 @@ http://www.gnu.org/software/emacs/manual/html_node/elisp/The-Echo-Area.html)"
   "Output translation below the paragraph with overlay."
   (let ((start (save-excursion (start-of-paragraph-text) (point)))
         (end (save-excursion (end-of-paragraph-text) (point)))
-        (below-paragraph (save-excursion (end-of-paragraph-text) (next-line) (point)))
+        (below-paragraph (if (eq major-mode 'org-mode)
+                             (save-excursion (previous-line) (point))
+                           (save-excursion (end-of-paragraph-text) (next-line) (point))))
         (translation (gtos-translation gtos)))
     (with-silent-modifications
       (put-text-property


### PR DESCRIPTION
This enhancement specificly for org-mode (which is the mostly used document format in Emacs).