### PR TITLE
Drop google-translate-pkg.el

### DIFF
--- a/google-translate-pkg.el
+++ b/google-translate-pkg.el
@@ -1,2 +1,0 @@
-(define-package "google-translate" "0.12.0"
-  "Emacs interface to Google Translate.")


### PR DESCRIPTION
This file is required by package.el, but it is generated on MELPA, so you don't have to put it in the repository.

#130 has added popup dependency to the library header, while google-translate-pkg.el contains no dependency information, so  there is currently an inconsistency between the two sources. I would recommend you simply remove the file, so you don't have to maintain the latter source.