### PR TITLE
Fix: translation to kill-ring for inserting

### DIFF
--- a/google-translate-core-ui.el
+++ b/google-translate-core-ui.el
@@ -723,10 +723,10 @@ At last will save result translation to `google-translate-result-translation'."
          ((equal output-destination 'paragraph-overlay)
           (google-translate-paragraph-overlay-output-translation gtos))
          ((equal output-destination 'paragraph-insert)
-          (google-translate-paragraph-insert-output-translation gtos)))))
-    (setq google-translate-result-translation (gtos-translation gtos))
-    (when google-translate-result-to-kill-ring
-      (kill-new google-translate-result-translation))))
+          (google-translate-paragraph-insert-output-translation gtos)))
+        (setq google-translate-result-translation (gtos-translation gtos))
+        (when google-translate-result-to-kill-ring
+          (kill-new google-translate-result-translation))))))
 
 (defun google-translate-popup-output-translation (gtos)
   "Output translation to the popup tooltip using `popup'

--- a/google-translate-core-ui.el
+++ b/google-translate-core-ui.el
@@ -725,7 +725,7 @@ At last will save result translation to `google-translate-result-translation'."
          ((equal output-destination 'paragraph-insert)
           (google-translate-paragraph-insert-output-translation gtos)))
         (setq google-translate-result-translation (gtos-translation gtos))
-        (when google-translate-result-to-kill-ring
+        (when google-translate-translation-to-kill-ring
           (kill-new google-translate-result-translation))))))
 
 (defun google-translate-popup-output-translation (gtos)


### PR DESCRIPTION
I tried `translation to kill-ring for inserting` and got an error, so I fixed it.

- Moved `gtos` code since it is a local variable that can be used in `let`.
- Fixed to use customized variable `google-translate-translation-to-kill-ring` since `google-translate-result-to-kill-ring` used to determine is undefined.

ref: https://github.com/atykhonov/google-translate/pull/120/