### PR TITLE
replace mplayer with ffplay

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,12 +242,11 @@ variable to t.
 
 The variable `google-translate-listen-program` determines the program
 to use to listen translations. By default the program looks for
-`mplayer` in the PATH, if `mplayer` is found then listening function
-will be available and you'll see `Listen` button in the buffer with
-the translation. You can use any other suitable program. If you use
-Windows please download and unpack `mplayer` and add its path
-(directory) to to the system PATH variable. Please note that
-translation listening is not available if
+`ffplay` in the PATH. `ffplay` is part of ffmpeg bundle, if executable
+found then listening command will be available and you'll see
+`Listen` button in the translation buffer. You can use any
+other suitable program. 
+Please note that translation listening is not available if
 `google-translate-output-destination` is set to `echo-area` or
 `pop-up`.
 

--- a/google-translate-core-ui.el
+++ b/google-translate-core-ui.el
@@ -314,15 +314,20 @@ query parameter in HTTP requests.")
                  (const :tag "Yes" t)))
 
 (defcustom google-translate-listen-program
-  (executable-find "mplayer")
+  (executable-find "ffplay")
   "The program to use to listen translations.
 
-By default the program looks for `mplayer' in the PATH, if
-`mplayer' is found then listening function will be available and
-you'll see `Listen' button in the buffer with the translation.
+By default the program looks for `ffplay' (included in ffmpeg) in the PATH, if
+the exec found, listening function will be available and
+`Listen' button in the buffer provided with the translation.
 You can use any other suitable program."
   :group 'google-translate-core-ui
   :type '(string))
+
+(defcustom google-translate-listen-program-args '("-nodisp" "-autoexit" "-loglevel" "quiet")
+  "Arguments to pass to the listen program before the urls."
+  :group 'google-translate-core-ui
+  :type '(repeat string))
 
 (defcustom google-translate-output-destination
   nil
@@ -659,19 +664,31 @@ clicked."
         (language (button-get button 'language)))
     (google-translate-listen-translation language text)))
 
+
 (defun google-translate-listen-translation (language text)
-  (let ((buf "*mplayer output*"))
+  "Play audio of TEXT spoken in LANGUAGE using external program.
+
+Retrieves audio from Google Translate's text-to-speech service
+and plays it using `google-translate-listen-program' with
+optional arguments from `google-translate-listen-program-args'.
+
+LANGUAGE is the language code (e.g., \"en\", \"es\", \"fr\").
+TEXT is the string to be spoken."
+  (let ((buf (format "*%s output*" google-translate-listen-program))
+        (urls (google-translate-format-listen-urls text language)))
     (message "Retrieving audio message...")
     (if google-translate-translation-listening-debug
         (with-current-buffer (get-buffer-create buf)
           (insert (format "Listen program: %s\r\n" google-translate-listen-program))
-          (mapc (lambda (x) (insert (format "Listen URL: %s\r\n" x)))
-                (google-translate-format-listen-urls text language))
+          (mapc (lambda (x) (insert (format "Listen URL: %s\r\n" x))) urls)
           (apply 'call-process google-translate-listen-program nil t nil
-                 (google-translate-format-listen-urls text language))
+                 (append google-translate-listen-program-args urls))
           (switch-to-buffer buf))
-      (apply 'call-process google-translate-listen-program nil nil nil
-             (google-translate-format-listen-urls text language)))))
+      ;; Use start-process for non-blocking playback
+      (apply 'start-process "google-translate-listen" nil
+             google-translate-listen-program
+             (append google-translate-listen-program-args urls)))))
+
 
 (defun google-translate-translate (source-language target-language text &optional output-destination)
   "Translate TEXT from SOURCE-LANGUAGE to TARGET-LANGUAGE.


### PR DESCRIPTION
I recently realized that mplayer project for Mac is now deprecated and I started looking for alternatives. Turns out, `ffplay` that comes bundled with ffmpeg (which is pretty ubiquitous these days) can be perfectly used. It only required adding a var for additional CLI args. I think this option is better than mplayer, due to the higher chance that no additional work would be needed from the user and I believe it to be a bit more lightweight than mplayer.

In case you don't like replacing the default option, I can make changes to only add the optional args var, leaving mplayer as the default option.

I tested this on Mac and it worked off the bat in Linux. I don't have immediate access to Windows machine at the moment, but I think it should just work, as long the program is on the PATH.